### PR TITLE
Add placeholder audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ On startup the server calls the URL in the environment variable `UPDATE_URL`. Th
 
 Further details about the audit can be found in `docs/audit-details.md`.
 
+### Audit modules
+
+The following modules are prepared for future checks:
+
+- `gtmAnalysis`: will inspect the Google Tag Manager setup and return a list of issues.
+- `consentCheck`: will verify consent mode settings and report detected platforms.
+- `cookieCheck`: will list cookies before and after consent with category and source.
+
 ## Metadata
 
 Ersteller: Patrick Gundlach – person to person Media (<https://patrickgundlach.de> / <https://ptp-media.com>)

--- a/docs/audit-details.md
+++ b/docs/audit-details.md
@@ -2,6 +2,14 @@
 
 This document outlines the information that each audit should provide in the platform.
 
+### Module overview
+
+TrackCheck groups the checks into simple modules:
+
+- **gtmAnalysis** returns details about the Tag Manager container.
+- **consentCheck** reports the consent setup and detected platform.
+- **cookieCheck** lists cookies with category and lifetime.
+
 ## Project Overview
 - List all projects with current status and last audit date.
 - Display audit history with version number, author and timestamp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trackcheck",
-  "version": "1.0.0",
+  "version": "00.00.01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trackcheck",
-      "version": "1.0.0",
+      "version": "00.00.01",
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",

--- a/src/audits/consentCheck.js
+++ b/src/audits/consentCheck.js
@@ -1,0 +1,5 @@
+function consentCheck() {
+  // TODO: implement consent detection logic
+}
+
+module.exports = { consentCheck };

--- a/src/audits/cookieCheck.js
+++ b/src/audits/cookieCheck.js
@@ -1,0 +1,5 @@
+function cookieCheck() {
+  // TODO: implement cookie verification logic
+}
+
+module.exports = { cookieCheck };

--- a/src/audits/gtmAnalysis.js
+++ b/src/audits/gtmAnalysis.js
@@ -1,0 +1,5 @@
+function gtmAnalysis() {
+  // TODO: implement GTM analysis logic
+}
+
+module.exports = { gtmAnalysis };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const { currentVersion } = require('../config/version');
 const { checkForUpdate } = require('./updateCheck');
+const { gtmAnalysis } = require('./audits/gtmAnalysis');
+const { consentCheck } = require('./audits/consentCheck');
+const { cookieCheck } = require('./audits/cookieCheck');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -14,4 +17,8 @@ app.listen(port, () => {
   console.log(`TrackCheck running on port ${port}`);
   console.log(`Current version: ${currentVersion}`);
   checkForUpdate(updateUrl, currentVersion);
+  // Future audits will be called here
+  gtmAnalysis();
+  consentCheck();
+  cookieCheck();
 });


### PR DESCRIPTION
## Summary
- create placeholder audit modules
- wire up audits in the server
- document planned modules

## Testing
- `npm install`
- `npm start` (stopped after startup)

------
https://chatgpt.com/codex/tasks/task_e_686910b8cde48326ad45398c6f5f4a77