### PR TITLE
Add setup script and refactor server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Current version: **00.00.01**
 ## Installation
 
 1. Clone the repository.
-2. Run `npm run setup` to install dependencies and create a `.env` file.
+2. Run `npm run setup` to install dependencies. The script also copies `.env.example` to `.env` if needed.
 3. Start the server with `npm start`.
 
 The server listens on port `3000` by default. Visit `/version` to see the active version.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ Current version: **00.00.01**
 ## Installation
 
 1. Clone the repository.
-2. Run `npm install` to install dependencies.
-3. Copy `.env.example` to `.env` if custom settings are needed.
-4. Start the server with `npm start`.
+2. Run `npm run setup` to install dependencies and create a `.env` file.
+3. Start the server with `npm start`.
 
 The server listens on port `3000` by default. Visit `/version` to see the active version.
 
@@ -25,6 +24,14 @@ On startup the server calls the URL in the environment variable `UPDATE_URL`. Th
 ## Documentation
 
 Further details about the audit can be found in `docs/audit-details.md`.
+
+### Audit modules
+
+The following modules are prepared for future checks:
+
+- `gtmAnalysis`: will inspect the Google Tag Manager setup and return a list of issues.
+- `consentCheck`: will verify consent mode settings and report detected platforms.
+- `cookieCheck`: will list cookies before and after consent with category and source.
 
 ## Metadata
 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ The following modules are prepared for future checks:
 
 Ersteller: Patrick Gundlach – person to person Media (<https://patrickgundlach.de> / <https://ptp-media.com>)
 
+
+### Troubleshooting
+If you see merge conflict markers like <<<<<<< or >>>>>>>, open the listed files and keep the desired lines before committing the result.

--- a/docs/audit-details.md
+++ b/docs/audit-details.md
@@ -2,6 +2,14 @@
 
 This document outlines the information that each audit should provide in the platform.
 
+### Module overview
+
+TrackCheck groups the checks into simple modules:
+
+- **gtmAnalysis** returns details about the Tag Manager container.
+- **consentCheck** reports the consent setup and detected platform.
+- **cookieCheck** lists cookies with category and lifetime.
+
 ## Project Overview
 - List all projects with current status and last audit date.
 - Display audit history with version number, author and timestamp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trackcheck",
-  "version": "1.0.0",
+  "version": "00.00.01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trackcheck",
-      "version": "1.0.0",
+      "version": "00.00.01",
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
+    "setup": "node setup.js",
     "start": "node src/index.js"
   },
   "keywords": [],

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+function installPackages() {
+  execSync('npm install', { stdio: 'inherit' });
+}
+
+function copyEnvFile() {
+  if (!fs.existsSync('.env') && fs.existsSync('.env.example')) {
+    fs.copyFileSync('.env.example', '.env');
+    console.log('.env file created');
+  }
+}
+
+function setup() {
+  installPackages();
+  copyEnvFile();
+}
+
+setup();

--- a/src/audits/consentCheck.js
+++ b/src/audits/consentCheck.js
@@ -1,0 +1,5 @@
+function consentCheck() {
+  // TODO: implement consent detection logic
+}
+
+module.exports = { consentCheck };

--- a/src/audits/cookieCheck.js
+++ b/src/audits/cookieCheck.js
@@ -1,0 +1,5 @@
+function cookieCheck() {
+  // TODO: implement cookie verification logic
+}
+
+module.exports = { cookieCheck };

--- a/src/audits/gtmAnalysis.js
+++ b/src/audits/gtmAnalysis.js
@@ -1,0 +1,5 @@
+function gtmAnalysis() {
+  // TODO: implement GTM analysis logic
+}
+
+module.exports = { gtmAnalysis };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const { currentVersion } = require('../config/version');
 const { checkForUpdate } = require('./updateCheck');
+const { gtmAnalysis } = require('./audits/gtmAnalysis');
+const { consentCheck } = require('./audits/consentCheck');
+const { cookieCheck } = require('./audits/cookieCheck');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -10,8 +13,16 @@ app.get('/version', (req, res) => {
   res.json({ version: currentVersion });
 });
 
+function runAudits() {
+  gtmAnalysis();
+  consentCheck();
+  cookieCheck();
+}
+
 app.listen(port, () => {
   console.log(`TrackCheck running on port ${port}`);
   console.log(`Current version: ${currentVersion}`);
   checkForUpdate(updateUrl, currentVersion);
+  // Future audits will be called here
+  runAudits();
 });


### PR DESCRIPTION
## Summary
- add setup script for quick installation
- update README with new setup command
- expose audit execution through a helper function
- add package.json script for setup

## Testing
- `npm run setup`
- `npm start` (stopped after startup)


------
https://chatgpt.com/codex/tasks/task_e_686910b8cde48326ad45398c6f5f4a77